### PR TITLE
fix readme directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Clone the [MiniGPT-4](https://github.com/Vision-CAIR/MiniGPT-4) repository and p
 ```sh
 cd minigpt4
 git clone https://github.com/Vision-CAIR/MiniGPT-4.git
+cd MiniGPT-4
 conda env create -f environment.yml
 conda activate minigpt4
 ```


### PR DESCRIPTION
The path listed in README.md is a directory where environment.yml does not exist, so it has been corrected.