### PR TITLE
Suggestion: git-ignore compiled files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,9 @@ models/*
 __pycache__
 .idea
 Makefile
+
+# Compiled files
+*.dylib
+*.so 
+*.bin
+*.dll


### PR DESCRIPTION
Suggestion: git-ignore compiled files (*.dylib, *.so, *.bin, *.dll), so they won't get in the way when committing files in the repository.

<img width="245" alt="image" src="https://github.com/Maknee/minigpt4.cpp/assets/418083/9a5f4069-00ef-49ac-bf1a-812f1eabf85f">
