### PR TITLE
Avoid displaying KeyboardInterrupt exception on terminal if user arbitrarily interrupts the inference

### DIFF
--- a/minigpt4/minigpt4_library.py
+++ b/minigpt4/minigpt4_library.py
@@ -643,7 +643,12 @@ class MiniGPT4ChatBot:
             self.library.minigpt4_begin_chat(self.ctx, message, self.n_threads)
             chat = ''
             for _ in range(limit):
-                token = self.library.minigpt4_end_chat(self.ctx, self.n_threads, temp, top_k, top_p, tfs_z, typical_p, repeat_last_n, repeat_penalty, alpha_presence, alpha_frequency, mirostat, mirostat_tau, mirostat_eta, penalize_nl)
+                try:
+                    token = self.library.minigpt4_end_chat(self.ctx, self.n_threads, temp, top_k, top_p, tfs_z, typical_p, repeat_last_n, repeat_penalty, alpha_presence, alpha_frequency, mirostat, mirostat_tau, mirostat_eta, penalize_nl)
+                except KeyboardInterrupt:
+                    break
+                except Exception as exception:
+                    raise exception
                 chat += token
                 if self.library.minigpt4_contains_eos_token(token):
                     continue
@@ -762,7 +767,12 @@ if __name__ == "__main__":
         library.minigpt4_begin_chat(ctx, prompt, n_threads)
         chat  = ''
         while True:
-            token = library.minigpt4_end_chat(ctx, n_threads)
+            try:
+                token = library.minigpt4_end_chat(ctx, n_threads)
+            except KeyboardInterrupt:
+                break
+            except Exception as exception:
+                raise exception
             chat += token
             if library.minigpt4_contains_eos_token(token):
                 continue


### PR DESCRIPTION
Currently, if the user interrupts the inference via Ctrl/Cmd + C, it displays the following in the terminal:
```
Traceback (most recent call last):
  File "test.py", line 18, in <module>
    for output in minigpt4_chatbot.generate(
  File "minigpt4_library.py", line 646, in generate
    token = self.library.minigpt4_end_chat(self.ctx, self.n_threads, temp, top_k, top_p, tfs_z, typical_p, repeat_last_n, repeat_penalty, alpha_presence, alpha_frequency, mirostat, mirostat_tau, mirostat_eta, penalize_nl)
  File "minigpt4_library.py", line 419, in minigpt4_end_chat
    self.panic_if_error(self.library.minigpt4_end_chat(ctx.ptr, ctypes.pointer(token), n_threads, temp, top_k, top_p, tfs_z, typical_p, repeat_last_n, repeat_penalty, alpha_presence, alpha_frequency, mirostat, mirostat_tau, mirostat_eta, penalize_nl))
KeyboardInterrupt
```

Changes on this PR prevent the exception from being displayed if the user arbitrarily interrupts the inference, stopping the inference process cleanly.